### PR TITLE
ci: npm 12 changed the shape of pack --json, and it stopped the v0.31.0 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,10 @@ jobs:
         run: |
           npm pack --dry-run --json > /tmp/pack.json
           node -e '
-            const p = require("/tmp/pack.json")[0];
+            // npm 10 prints an ARRAY; npm 12 prints an OBJECT keyed by package name. The two
+            // jobs here run different npm versions, so read whichever shape arrives.
+            const raw = require("/tmp/pack.json");
+            const p = Array.isArray(raw) ? raw[0] : Object.values(raw)[0];
             const files = p.files.map(f => f.path).sort();
             const want = ["README.md", "bin/mastermind.mjs", "package.json"].sort();
             if (JSON.stringify(files) !== JSON.stringify(want))
@@ -90,7 +93,11 @@ jobs:
           npm pack --dry-run --json > /tmp/pack-stamped.json
           node -e '
             const fs = require("fs");
-            const p = require("/tmp/pack-stamped.json")[0];
+            // Same two shapes as the gate job. This step runs the PINNED npm, which is the
+            // one that changed, and reading only the array form is what stopped 0.31.0.
+            const raw = require("/tmp/pack-stamped.json");
+            const p = Array.isArray(raw) ? raw[0] : Object.values(raw)[0];
+            if (!p) { console.error("npm pack --json produced nothing usable"); process.exit(1) }
             const files = p.files.map(f => f.path).sort();
             const want = ["README.md", "bin/mastermind.mjs", "package.json"].sort();
             if (JSON.stringify(files) !== JSON.stringify(want))


### PR DESCRIPTION
The v0.31.0 publish run passed every gate and then failed in the publish job with
`TypeError: Cannot read properties of undefined (reading 'files')`.

`npm pack --dry-run --json` prints an **array** on npm 10 and an **object keyed by package
name** on npm 12. The gate job uses the runner's default npm; the publish job installs the
pinned `npm@12.0.2`. Same code, two shapes.

This failed in the right direction. The re-verification step runs before `npm publish`, so
v0.31.0 was blocked rather than shipped unverified, and nothing reached the registry.

Both readers now accept either shape, verified locally against npm 10.9.0 and npm 12.0.2:

```
npm         -> contents OK: README.md, bin/mastermind.mjs, package.json
npm@12.0.2  -> contents OK: README.md, bin/mastermind.mjs, package.json
```

After this merges, the v0.31.0 tag gets recreated on the new master and pushed again. Nothing
was published under that tag, so it has not been consumed by anyone.