### PR TITLE
docs: write down the credential and the parts of the flow that changed

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,7 @@ It runs `preflight.sh` and stops if anything fails. It does not commit, tag, pus
 ```
 git commit -am "release: v0.31.0"
 git -C ../mastermind-site commit -am "v0.31.0"
-git tag -a v0.31.0 -m "v0.31.0 — <the changelog's opening line>"
+git tag -a v0.31.0 -m "v0.31.0: <the changelog's opening line>"
 git push
 git push origin v0.31.0        # this is what publishes
 git -C ../mastermind-site push # this is what deploys the site
@@ -92,7 +92,8 @@ Pushing the tag is the only irreversible step. Nothing reaches npm before it.
 `publish.yml` will not publish unless, on that exact commit:
 
 - the tag matches `VERSION`
-- both suites, integrity, router, library, links, brain lint and the routing eval all pass
+- both suites, integrity, router, links, brain lint and the routing eval all pass
+- the library pages match the skill and agent sources, when CI can read the site (see below)
 - the packed tarball contains exactly `README.md`, `bin/mastermind.mjs`, `package.json`
 - **every** platform passes: Linux on Node 18 and 22, macOS, Alpine, WSL, the native-Windows
   refusal guard, and an install from the actual stamped tarball
@@ -105,15 +106,36 @@ The stamp matters: the tarball ships the CLI only, and the brain is cloned at in
 stamp is what ties a published version to one commit of this repository, and the CLI refuses a
 clone whose `HEAD` does not match it. That is what closes the moved-tag hole.
 
+**The library check needs the site repository, which is private.** It reads it with
+`MASTERMIND_SITE_KEY`, a read-only deploy key on `mastermind-site`. If that key is missing or
+revoked the checkout fails, the check is skipped, and the job summary says so; the release still
+goes out. That is deliberate: a release must not be held hostage by evidence CI cannot gather,
+and it must not pretend it gathered it either. If you see that warning, the published pages were
+not compared against the instructions behind them.
+
+### The website is checked separately
+
+`site-live.yml` runs daily and on demand against the deployed site, over HTTP, needing no
+repository access. It checks the version it shows, the pages people land on, the security
+headers, the content policy, and that every skill and agent we ship has a live page.
+
+It deliberately does not run on the release tag. The site is deployed from its own repository
+*after* the package tag is pushed, so running it then would test the previous deployment. The
+release checks the site with `verify-release.sh`, after the site push.
+
 ### 5. Verify all three surfaces agree
 
 ```
 scripts/verify-release.sh 0.31.0
 ```
 
-Checks the tag and the six version locations, that npm serves that version, that the published
+Checks the tag and every version location, that npm serves that version, that the published
 package is stamped with the commit the tag points at, that the site shows it, that the site's CSP
-still allows the embedded map, and that a Release object exists. Read-only.
+allows the origin the embedded map actually resolves to, and that a Release object exists.
+Read-only.
+
+Run it **after** pushing the site, not before: it reads the deployed site, so running it earlier
+reports the previous deployment.
 
 "Keep the repo, npm and the site in sync" used to mean remembering to open three tabs. Every part
 of it is a question a command can answer, so this asks them.
@@ -132,6 +154,11 @@ deploys on push to its own repository; the repo does not deploy it.
 **`preflight` reports checks it could not run.** That is not the same as passing, and it says so.
 A missing site checkout or an absent Claude CLI both land here. Decide whether shipping without
 that evidence is acceptable, and if it is, set the documented override so the gap is on the record.
+
+**The job summary says the library was not checked.** `MASTERMIND_SITE_KEY` is missing, revoked,
+or no longer valid on `mastermind-site`. Regenerate a read-only deploy key there and set the
+secret again. Until then the published pages are not being compared against the skill and agent
+sources, and only a person reading the pages would notice a mismatch.
 
 **A test fails only on macOS.** That is bash 3.2 and the `/tmp` and `/var` symlinks, which caused
 four separate path defects. Always resolve both sides of a path comparison before comparing them.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,10 +23,36 @@ Anything derived from a real, possibly-private codebase stays in `lab/`, which i
 
 - **pre-commit / pre-push** block any staged change that contains a quarantined `lab/` path, a
   denylisted identifier, or a common secret pattern (keys, tokens).
-- Distilled knowledge only leaves the Lab after every project, product, and person name is stripped —
+- Distilled knowledge only leaves the Lab after every project, product, and person name is stripped:
   **patterns, not identities.**
 
 To enable the guards after cloning: `git config core.hooksPath .githooks`.
+
+## What the release pipeline can reach
+
+Publishing runs on GitHub Actions and holds two credentials. Both are listed here because a
+credential nobody has written down is one nobody audits.
+
+**npm publishing** uses trusted publishing over OIDC. There is no npm token in this repository or
+in its secrets: the workflow exchanges a short-lived identity for permission to publish, and only
+the publish job requests it. Packages are published with provenance, and the exact commit is
+stamped into the published `package.json` so a version can be traced to one commit of this
+repository.
+
+**`MASTERMIND_SITE_KEY`** is a read-only deploy key for `mastermind-site`, the private repository
+holding the website. The release gate uses it to check that the published library pages still
+match the skill and agent instructions behind them.
+
+- It reads one repository and nothing else. A personal access token would have read every
+  repository the account owns, which is why this is a deploy key.
+- It cannot write. A push with it is refused by GitHub.
+- It does not expire, so nothing breaks silently on a renewal date.
+- To revoke: delete it from `mastermind-site` → Settings → Deploy keys, and delete the
+  `MASTERMIND_SITE_KEY` secret from this repository. The release still works afterwards; the
+  library check is skipped and the job summary says so.
+
+Actions are pinned to full commit SHAs rather than tags, so a moved tag upstream cannot change
+what runs. `npm` itself is pinned in the publish job for the same reason.
 
 ## Reporting a vulnerability
 
@@ -34,4 +60,4 @@ If you find leaked private data in the repo or history, a way to bypass the guar
 security issue, please **report it privately** via GitHub's
 [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
 on this repository rather than opening a public issue. This is an experimental, single-maintainer
-project — expect a best-effort response.
+project, so expect a best-effort response.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,7 +48,7 @@ edit() {
   fi
   local tmp; tmp="$(mktemp)"
   sed "$expr" "$file" > "$tmp"
-  cmp -s "$tmp" "$file" && { rm -f "$tmp"; die "$label: nothing changed in $file — the pattern no longer matches"; }
+  cmp -s "$tmp" "$file" && { rm -f "$tmp"; die "$label: nothing changed in $file, so the pattern no longer matches"; }
   cat "$tmp" > "$file"; rm -f "$tmp"
   ok "$label"
 }
@@ -91,7 +91,7 @@ ${b}Not done automatically, because each one leaves this machine:${x}
   1. review the diff          git diff --stat HEAD
   2. commit both repos        git commit -am "release: v$NEW"
                               git -C "$SITE" commit -am "v$NEW"
-  3. tag                      git tag -a "v$NEW" -m "v$NEW${SUBJECT:+ — $SUBJECT}"
+  3. tag                      git tag -a "v$NEW" -m "v$NEW${SUBJECT:+: $SUBJECT}"
   4. push the code            git push
   5. push the tag             git push origin "v$NEW"     ${y}# this publishes to npm${x}
   6. deploy the site          git -C "$SITE" push


### PR DESCRIPTION
`RELEASING.md` predated the deploy key, `site-live.yml`, and the private-repo behaviour, so it described a flow that no longer exists in three places.

It now records that the library check reads the site with `MASTERMIND_SITE_KEY`, that a missing key skips the check with a warning rather than failing the release, that `site-live.yml` checks the deployed site daily and deliberately **not** on the release tag (the site deploys after the tag, so running it then would test the previous deployment), and that `verify-release.sh` belongs after the site push.

`SECURITY.md` gains a section on what the release pipeline can reach: npm trusted publishing over OIDC with no stored token, and `MASTERMIND_SITE_KEY` with what it reads, that a push with it is refused, that it does not expire, and the two steps to revoke it. A credential nobody wrote down is one nobody audits.

`release.sh` was **generating** an em dash into every tag message it suggested. Fixed to a colon, matching the tags actually cut. Four other pre-existing ones in these files went too.

Docs and one script line, so no release. 15 preflight checks pass, shellcheck clean.