### PR TITLE
Close the fifth review: two blockers and fourteen more

### DIFF
--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -89,6 +89,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
+      # The same npm the release uses. Packing with the runner's default meant this job
+      # exercised an artifact built by a different tool than the one that ships.
+      - run: npm install -g npm@12.0.2 --registry=https://registry.npmjs.org
       - name: pack the CLI exactly as the release stamps it
         working-directory: cli
         run: |

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -19,3 +19,16 @@ jobs:
           node-version: 22
       - run: node scripts/check-integrity.mjs
       - run: node scripts/build-router.mjs --check   # ROUTER.md must be regenerated when routed files change
+
+  # Runs on every pull request with no path filter, so it can be a REQUIRED check. The cross-OS
+  # matrix is path-filtered and therefore cannot be required without deadlocking docs-only PRs,
+  # which left a failing installer suite able to merge. The full matrix still gates the release.
+  suites:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 22
+      - run: bash tests/install.test.sh
+      - run: bash tests/agent-surface.test.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: 22
       - run: |
           test "v$(cat VERSION)" = "$GITHUB_REF_NAME" || { echo "tag/VERSION mismatch"; exit 1; }
+          grep -q "^## \[${GITHUB_REF_NAME#v}\]" CHANGELOG.md ||
+            { echo "CHANGELOG.md has no section for ${GITHUB_REF_NAME#v}"; exit 1; }
       - run: bash tests/install.test.sh
       - run: bash tests/agent-surface.test.sh
       - run: node scripts/check-integrity.mjs
@@ -30,8 +32,10 @@ jobs:
       - run: node scripts/check-links.mjs
       - run: node scripts/lint-brain.mjs --strict
       - run: node evals/agent-surface-routing.mjs
-      # The site is a private repository. MASTERMIND_SITE_KEY is a read-only deploy key for it:
-      # scoped to that one repo, unlike a token that could read everything the account owns.
+      # MASTERMIND_SITE_KEY is a read-only deploy key for the private site repository, scoped to
+      # that one repo. This fails the release when it cannot read: the check exists to stop the
+      # published pages drifting from the instructions behind them, and a check that shrugs is
+      # not one. MM_ALLOW_UNCHECKED_LIBRARY=1 in the repo variables is the deliberate override.
       - id: sitesrc
         continue-on-error: true
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -44,11 +48,17 @@ jobs:
         env:
           MASTERMIND_SITE: ${{ github.workspace }}/site-checkout
         run: node scripts/build-library.mjs --check
-      - name: say so when the library could not be checked
+      - name: refuse to release without checking the library
         if: steps.sitesrc.outcome != 'success'
         run: |
-          echo "::warning::the site repository could not be read, so the library pages were NOT checked against the skill and agent sources. Check that MASTERMIND_SITE_KEY is still a valid deploy key on mastermind-site."
-          echo "· library check skipped: no access to the site repository" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ vars.MM_ALLOW_UNCHECKED_LIBRARY }}" = "1" ]; then
+            echo "::warning::the site could not be read and MM_ALLOW_UNCHECKED_LIBRARY is set, so the library pages were NOT checked"
+            echo "· library check skipped by explicit override" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "::error::the site repository could not be read, so the library pages cannot be checked against the skill and agent sources."
+          echo "Fix MASTERMIND_SITE_KEY on mastermind-site, or set the repository variable MM_ALLOW_UNCHECKED_LIBRARY=1 to release without this evidence." >&2
+          exit 1
       - name: the published tarball contains exactly what we intend
         working-directory: cli
         run: |
@@ -105,15 +115,25 @@ jobs:
       # The gate job checked the tarball, but that was before the stamp rewrote package.json.
       # What actually ships is this file, so the contract is re-checked against it: the same
       # three paths, the version still matching the tag, and a real commit SHA in the stamp.
-      - name: re-verify the stamped package is what we intend to publish
+      # Pack ONCE, verify that file, publish that file. `npm publish` from the directory repacks,
+      # so what shipped was never the thing any check had looked at.
+      - name: pack the release artifact
         working-directory: cli
         run: |
-          npm pack --dry-run --json > /tmp/pack-stamped.json
+          set -e
+          npm pack --pack-destination "$RUNNER_TEMP" --json > "$RUNNER_TEMP/pack-stamped.json"
+          ls -l "$RUNNER_TEMP"/mastermind-brain-*.tgz
+
+      - name: re-verify the stamped package is what we intend to publish
+        working-directory: cli
+        env:
+          PACK_JSON: ${{ runner.temp }}/pack-stamped.json
+        run: |
           node -e '
             const fs = require("fs");
             // Same two shapes as the gate job. This step runs the PINNED npm, which is the
             // one that changed, and reading only the array form is what stopped 0.31.0.
-            const raw = require("/tmp/pack-stamped.json");
+            const raw = require(process.env.PACK_JSON);
             const p = Array.isArray(raw) ? raw[0] : Object.values(raw)[0];
             if (!p) { console.error("npm pack --json produced nothing usable"); process.exit(1) }
             const files = p.files.map(f => f.path).sort();
@@ -130,8 +150,33 @@ jobs:
               { console.error("commit stamp does not match this run"); process.exit(1) }
             console.log(`stamped package OK: v${pkg.version} @ ${pkg.commit}`);
           '
-      - run: npm publish --provenance --access public
+      # Prepared BEFORE publishing. Extracting the notes afterwards meant a missing changelog
+      # section published npm permanently and then failed, leaving no Release and no way back.
+      - name: prepare the release notes
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -e
+          V="${TAG#v}"
+          notes="$(awk -v v="## [$V]" '
+            index($0, v) == 1 { inb = 1; next }
+            inb && /^## \[/    { exit }
+            inb                { print }
+          ' CHANGELOG.md)"
+          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            echo "CHANGELOG.md has no '## [$V]' section, so there are no notes to publish" >&2
+            exit 1
+          fi
+          printf '%s\n' "$notes" > "$RUNNER_TEMP/notes.md"
+          echo "release notes ready: $(wc -l < "$RUNNER_TEMP/notes.md") lines"
+
+      - name: publish the artifact that was verified
         working-directory: cli
+        run: |
+          set -e
+          tgz="$(ls "$RUNNER_TEMP"/mastermind-brain-*.tgz)"
+          echo "publishing $tgz"
+          npm publish "$tgz" --provenance --access public
 
       # Six tags shipped without one, because creating it was a step someone had to remember
       # after the excitement of publishing. The changelog already contains the notes, so this
@@ -142,21 +187,9 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -e
-          V="${TAG#v}"
-          # The section for this version, without its own heading line.
-          notes="$(awk -v v="## [$V]" '
-            index($0, v) == 1 { inb = 1; next }
-            inb && /^## \[/    { exit }
-            inb                { print }
-          ' CHANGELOG.md)"
-          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
-            echo "CHANGELOG.md has no '## [$V]' section, so there are no notes to publish" >&2
-            exit 1
-          fi
-          printf '%s\n' "$notes" > /tmp/notes.md
           title="$(git tag -l --format='%(contents:subject)' "$TAG" | head -1)"
           [ -n "$title" ] || title="$TAG"
           # --latest explicitly: GitHub marks the most recently CREATED release as latest, not
           # the highest version, so backfilling an older tag silently demotes the current one.
-          gh release create "$TAG" --title "$title" --notes-file /tmp/notes.md --verify-tag --latest
+          gh release create "$TAG" --title "$title" --notes-file "$RUNNER_TEMP/notes.md" --verify-tag --latest
           echo "released $TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,65 @@ Notable changes to MasterMind. Format follows [Keep a Changelog](https://keepach
 MasterMind is **experimental** and pre-1.0, so minor versions may change behavior. Full commit
 history lives in git.
 
+## [0.31.3] · 2026-08-10
+
+A further external review found 16 issues. All 16 are addressed here. Two were release blockers.
+
+### Fixed: the installer could write outside the project
+
+The containment guard covered the engine files it ships and not the state it keeps. A repository
+that shipped a dangling symlink at `.mastermind/routes.map` or `.mastermind/.manifest.hashes`
+made the installer create a file anywhere on the machine, and the install still exited 0.
+
+Every path the brain writes is now checked, including the context directories named at run time
+by `routes.map`. Reproduced against 0.31.2 for both paths, and covered by tests that fail there.
+
+### Fixed: the release could publish to npm and then fail
+
+The GitHub Release notes were read from the changelog *after* `npm publish`. A missing changelog
+section published npm permanently and then errored, leaving a version on the registry with no
+release behind it. The notes are prepared and proven first, and the gate now refuses a tag whose
+version has no changelog section before any job runs.
+
+`npm publish` also repacked the package rather than publishing the file that had just been
+verified, so what shipped was never the artifact any check had inspected. One tarball is now
+packed, verified and published, and the cross-platform job exercises it with the same pinned npm.
+
+### Fixed: preservation and state
+
+- A project's own symlink was treated as ours whenever it happened to resolve inside the brain,
+  so `AGENTS.md` pointing at a file in `.mastermind/` was replaced with no backup and removed on
+  uninstall. Ownership now means pointing at exactly what we would create.
+- Two projects whose paths differ only where the old key sanitised them, `a/b` and `a_b`, shared
+  one install record and inherited each other's expected tools. Records are keyed by a hash of
+  the path. Records written under the old key are still read.
+- Retired tool names were recorded as installed while wiring nothing, and the doctor then
+  reported the project healthy. They are accepted for uninstall and never recorded.
+
+### Changed
+
+- An unknown flag is rejected before the brain is cloned. `--bogus` used to clone first and
+  refuse afterwards, leaving state behind for a command that never ran.
+- The library check fails the release when it cannot read the site, rather than warning. The
+  repository variable `MM_ALLOW_UNCHECKED_LIBRARY` is the deliberate override.
+- The installer suites run on every pull request, so a red suite can be made a required check.
+  The cross-platform matrix stays a release gate.
+- `agents` is no longer listed as a tool you name: `AGENTS.md` is always wired, and
+  `mastermind agents` lists the agents.
+- 87 em dashes removed from installer and CLI output. The pointer line MasterMind appends
+  changed with them, so the previous wording is still recognised and cleaned up; without that,
+  our text would have been stranded in the files of everyone who installed before this release.
+
+### Website
+
+- The interactive map is no longer embedded on arrival. It loads when asked, sandboxed and with
+  no referrer, so reading the architecture page does not announce the visit to a third party.
+- The router section claimed a task loads one or two files. Across the measured tasks it was two
+  to four, and the panel now says which numbers describe the illustration and which the average.
+- A failed copy showed nothing to a sighted reader: the button said "copy" whether or not it had
+  worked. It now shows the failure and still announces it.
+- The Codex link landed on a generic documentation root. It points at the CLI documentation.
+
 ## [0.31.2] · 2026-08-10
 
 ### Fixed

--- a/cli/bin/mastermind.mjs
+++ b/cli/bin/mastermind.mjs
@@ -30,8 +30,9 @@ if (argv.includes('--help') || argv.includes('-h')) {
   mastermind update           update the brain and repair this project
   mastermind uninstall        remove MasterMind wiring from this project
   mastermind skills           list the skill routing table
+  mastermind agents           list the agents
 
-Tools:   claude · cursor · codex · agents
+Tools:   claude · cursor · codex        AGENTS.md is always wired, so it is not a tool you name
 Flags:   --global · --shared · --isolated · --json
 
 Requires: Bash, Git, and Node 18 or newer. On Windows, run it inside WSL.`)
@@ -40,6 +41,15 @@ Requires: Bash, Git, and Node 18 or newer. On Windows, run it inside WSL.`)
 if (argv.includes('--version') || argv.includes('-V')) {
   console.log(VERSION)
   process.exit(0)
+}
+
+// Rejected BEFORE anything is cloned, fetched or written. An unknown flag used to exit 2 only
+// after the brain had been cloned, so a typo left state behind on a command that never ran.
+const FLAGS = ['--global', '--shared', '--isolated', '--json', '--check', '--uninstall']
+const badFlag = argv.find((a) => a.startsWith('-') && !FLAGS.includes(a))
+if (badFlag) {
+  console.error(`unknown flag: ${badFlag}\nflags: ${FLAGS.join(' · ')}`)
+  process.exit(2)
 }
 
 const cmdAt = argv.findIndex((a) => !a.startsWith('-'))
@@ -82,7 +92,7 @@ const fail = (msg) => {
 // verifyCommit throws through fail() -> process.exit, so cleanup must happen before it runs.
 
 if (process.platform === 'win32') {
-  fail('Native Windows is not supported yet — run this inside WSL, where it works as-is.\n'
+  fail('Native Windows is not supported yet: run this inside WSL, where it works as-is.\n'
     + '  Git Bash will not work either: it runs the Windows build of Node, which lands here too.')
 }
 
@@ -183,7 +193,7 @@ if (READ_CMDS.includes(cmd)) {
     else writeAll(2, `✖ ${msg}\n`)
     process.exit(1)
   }
-  if (!brain) refuse('no brain found — run `npx mastermind-brain` in this project first')
+  if (!brain) refuse('no brain found: run `npx mastermind-brain` in this project first')
   if (cmd === 'wrong-log') {
     const journal = join(brain, 'journal.md')
     const lines = existsSync(journal)
@@ -195,7 +205,7 @@ if (READ_CMDS.includes(cmd)) {
       { journal, count: lines.length, entries: lines },
       lines.length
         ? lines.join('\n')
-        : `no misses recorded yet in ${journal} — that means nothing has been logged, not that nothing was wrong`,
+        : `no misses recorded yet in ${journal}: that means nothing has been logged, not that nothing was wrong`,
     )
   }
 
@@ -243,11 +253,11 @@ if (READ_CMDS.includes(cmd)) {
       { brain, foreign: foreign.map(({ name, from }) => ({ name, from })), collisions,
         note: 'Precedence: this project\'s own skills → installed packs → MasterMind defaults. On a rule conflict the stricter rule wins.' },
       foreign.length === 0
-        ? 'no other skill packs installed — nothing to collide with'
+        ? 'no other skill packs installed: nothing to collide with'
         : [
             `${foreign.length} foreign skill(s) installed beside ${ours.length} MasterMind skills`,
             ...collisions.map((c) => c.kind === 'name'
-              ? `name   ${c.foreign} — same name as ours (yours is used; ours is mastermind-${c.foreign})`
+              ? `name   ${c.foreign}: same name as ours (yours is used; ours is mastermind-${c.foreign})`
               : `overlap ${c.foreign} ≈ ${c.ours} (${Math.round(c.share * 100)}% shared triggers)`),
             '',
             'Precedence: your project\'s skills → installed packs → MasterMind defaults.',
@@ -274,7 +284,7 @@ if (READ_CMDS.includes(cmd)) {
     if (!hit) {
       const near = items.filter((i) => i.name.includes(want) || want.includes(i.name))
       refuse(
-        `no ${kind} named "${want}"${near.length ? ` — did you mean ${near.map((n) => n.name).join(', ')}?` : ''}`,
+        `no ${kind} named "${want}"${near.length ? `: did you mean ${near.map((n) => n.name).join(', ')}?` : ''}`,
         { available: names },
       )
     }
@@ -299,13 +309,13 @@ if (READ_CMDS.includes(cmd)) {
         hints: [...hintNames],
         skills: allSkills.map(({ name, description }) => ({ name, description, hint: hintNames.has(name) })),
         agents: allAgents.map(({ name, description }) => ({ name, description, hint: hintNames.has(name) })),
-        note: 'the full table; → marks keyword overlap only. Keyword matching is unreliable on natural phrasing — judge from the descriptions, do not trust the arrows.',
+        note: 'the full table; → marks keyword overlap only. Keyword matching is unreliable on natural phrasing: judge from the descriptions, do not trust the arrows.',
       },
       [
         ...allSkills.map((s) => line('skill', s)),
         ...allAgents.map((a) => line('agent', a)),
         '',
-        '→ marks keyword overlap only, and it is often wrong — choose from the descriptions.',
+        '→ marks keyword overlap only, and it is often wrong: choose from the descriptions.',
         'then: mastermind skill <name>',
       ].join('\n'),
     )
@@ -315,9 +325,9 @@ if (READ_CMDS.includes(cmd)) {
 try {
   execFileSync('git', ['--version'], { stdio: 'ignore' })
 } catch {
-  fail('git is required (the brain is a git repo — that is also how you audit it).')
+  fail('git is required (the brain is a git repo: that is also how you audit it).')
 }
-// install.sh is the engine, and Alpine — the usual CI base image — ships without bash.
+// install.sh is the engine, and Alpine: the usual CI base image: ships without bash.
 try {
   execFileSync('bash', ['--version'], { stdio: 'ignore' })
 } catch {
@@ -334,7 +344,7 @@ const verifyCommit = (where, { cleanupOnMismatch = false } = {}) => {
   if (!PINNED_COMMIT) return // local checkout / unpublished: nothing to verify against
   let head = ''
   try { head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: where, encoding: 'utf8' }).trim() }
-  catch { bail(`cannot read the commit at ${where} — refusing to install unverified code.`) }
+  catch { bail(`cannot read the commit at ${where}: refusing to install unverified code.`) }
   if (head !== PINNED_COMMIT)
     bail(`brain at ${where} is commit ${head.slice(0, 12)}, but this release pins ${PINNED_COMMIT.slice(0, 12)}.\n`
       + '  The tag may have moved. Refusing to install code this release did not publish.')
@@ -343,7 +353,7 @@ const verifyCommit = (where, { cleanupOnMismatch = false } = {}) => {
     dirty = execFileSync('git', ['status', '--porcelain', '--untracked-files=no'],
       { cwd: where, encoding: 'utf8' }).trim()
   } catch {
-    bail(`cannot read the working tree at ${where} — refusing to run code this release cannot verify.\n`
+    bail(`cannot read the working tree at ${where}: refusing to run code this release cannot verify.\n`
       + `  Check it by hand: git -C ${where} status`)
   }
   if (dirty) {
@@ -363,7 +373,7 @@ if (!existsSync(MM_HOME)) {
   }
   verifyCommit(MM_HOME, { cleanupOnMismatch: true })
 } else if (!existsSync(join(MM_HOME, 'install.sh'))) {
-  fail(`${MM_HOME} exists but doesn't look like the MasterMind repo — move it aside and re-run.`)
+  fail(`${MM_HOME} exists but doesn't look like the MasterMind repo: move it aside and re-run.`)
 } else if (PINNED_COMMIT && !existsSync(join(MM_HOME, '.git'))) {
   fail(`${MM_HOME} has no git history, so this release cannot verify what it would run.\n`
     + `  A published MasterMind only executes the commit it was built from.\n`
@@ -375,13 +385,13 @@ if (!existsSync(MM_HOME)) {
     try { git(['symbolic-ref', '-q', 'HEAD']) } catch { onBranch = false }
     if (onBranch && !PINNED_COMMIT) {
       const st = run('git', ['pull', '--ff-only'], { cwd: MM_HOME })
-      if (st !== 0) fail(`update refused — ${MM_HOME} has local changes. Keep them: git -C ${MM_HOME} stash && npx mastermind-brain update. Discard them: git -C ${MM_HOME} checkout -- . && npx mastermind-brain update`)
+      if (st !== 0) fail(`update refused: ${MM_HOME} has local changes. Keep them: git -C ${MM_HOME} stash && npx mastermind-brain update. Discard them: git -C ${MM_HOME} checkout -- . && npx mastermind-brain update`)
     }
     else {
       const f = run('git', ['fetch', '--tags', '--depth', '1', 'origin', `refs/tags/${PIN}:refs/tags/${PIN}`], { cwd: MM_HOME })
-      if (f !== 0) fail(`could not fetch ${PIN} from ${REPO_URL} — the brain is unchanged; nothing was installed.`)
+      if (f !== 0) fail(`could not fetch ${PIN} from ${REPO_URL}: the brain is unchanged; nothing was installed.`)
       const c = run('git', ['checkout', '-q', PIN], { cwd: MM_HOME })
-      if (c !== 0) fail(`could not check out ${PIN} — the brain is unchanged; nothing was installed.`)
+      if (c !== 0) fail(`could not check out ${PIN}: the brain is unchanged; nothing was installed.`)
       verifyCommit(MM_HOME)
     }
   }
@@ -389,11 +399,11 @@ if (!existsSync(MM_HOME)) {
     let head = ''
     try { head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: MM_HOME, encoding: 'utf8' }).trim() } catch { /* verifyCommit reports it */ }
     if (head && head !== PINNED_COMMIT) {
-      console.log(`↻ brain at ${MM_HOME} is behind this release — syncing to ${PIN}`)
+      console.log(`↻ brain at ${MM_HOME} is behind this release: syncing to ${PIN}`)
       run('git', ['fetch', '--tags', '--depth', '1', 'origin', `refs/tags/${PIN}:refs/tags/${PIN}`], { cwd: MM_HOME })
       const c = run('git', ['checkout', '-q', PIN], { cwd: MM_HOME })
       if (c !== 0)
-        fail(`could not update ${MM_HOME} to ${PIN} — the brain is unchanged.\n`
+        fail(`could not update ${MM_HOME} to ${PIN}: the brain is unchanged.\n`
           + `  Fix it by hand: git -C ${MM_HOME} fetch --tags && git -C ${MM_HOME} checkout ${PIN}`)
     }
   }
@@ -404,6 +414,6 @@ if (!existsSync(MM_HOME)) {
 const engineArgs =
   cmd === 'check' ? ['--check', ...passthrough]
   : cmd === 'uninstall' ? ['--uninstall', ...passthrough]
-  : passthrough // init and update both end in a (re)install — that is the self-heal contract
+  : passthrough // init and update both end in a (re)install: that is the self-heal contract
 
 process.exit(run('bash', [join(MM_HOME, 'install.sh'), ...engineArgs], { cwd: process.cwd() }))

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ for a in "$@"; do
     --check|--uninstall)
       _m="${a#--}"
       if [ -n "$MODE_FLAG" ] && [ "$MODE_FLAG" != "$_m" ]; then
-        printf '%s and --%s do different things — pick one.\n' "--$MODE_FLAG" "$_m" >&2; exit 2
+        printf '%s and --%s do different things: pick one.\n' "--$MODE_FLAG" "$_m" >&2; exit 2
       fi
       MODE_FLAG="$_m"; MODE="$_m" ;;
     --global)    SCOPE=global ;;
@@ -53,7 +53,7 @@ for _t in ${TOOLS+"${TOOLS[@]}"}; do
 done
 
 if [ "$ISOLATED" = 1 ] && [ "$SHARED" = 1 ]; then
-  printf '%s\n' '--isolated and --shared are opposite modes — pick one.' >&2
+  printf '%s\n' '--isolated and --shared are opposite modes: pick one.' >&2
   exit 2
 fi
 
@@ -66,13 +66,17 @@ ok()   { printf '  %s✓%s %s\n' "$g" "$x" "$*"; }
 warn() { printf '  %s⚠%s %s\n' "$y" "$x" "$*"; }
 bad()  { printf '  %s✖%s %s\n' "$r" "$x" "$*"; }
 ISSUES=0; LINKED_SKILLS=0; LINKED_AGENTS=0; PRUNED=0; RENAMED=0; SKIPPED=0; UNFINISHED=0
-HINT='Follow ~/.mastermind/CLAUDE.md — the MasterMind brain (skills, agents, engineering rigor).'
+HINT='Follow ~/.mastermind/CLAUDE.md: the MasterMind brain (skills, agents, engineering rigor).'
 HINT_GLOBAL="$HINT"
-HINT_ISOLATED='Follow ./.mastermind/CLAUDE.md — the MasterMind brain for this project (skills, agents, engineering rigor).'
+HINT_ISOLATED='Follow ./.mastermind/CLAUDE.md: the MasterMind brain for this project (skills, agents, engineering rigor).'
+# Every release up to 0.31.2 wrote these with an em dash. Cleanup matches the whole line, so
+# dropping the old forms would strand our pointer in the files of everyone who installed before.
+HINT_LEGACY_GLOBAL='Follow ~/.mastermind/CLAUDE.md — the MasterMind brain (skills, agents, engineering rigor).'
+HINT_LEGACY_ISOLATED='Follow ./.mastermind/CLAUDE.md — the MasterMind brain for this project (skills, agents, engineering rigor).'
 # Set once $BRAIN/$PROJECT are known (below): an isolated project must point at its OWN brain.
 mm_hint() {
   if [ "$ISOLATED" = 1 ]; then
-    printf 'Follow ./.mastermind/CLAUDE.md — the MasterMind brain for this project (skills, agents, engineering rigor).'
+    printf 'Follow ./.mastermind/CLAUDE.md: the MasterMind brain for this project (skills, agents, engineering rigor).'
   else
     printf '%s' "$HINT"
   fi
@@ -84,8 +88,19 @@ mm_record_file() {
   elif [ -d "$PROJECT/.mastermind" ]; then
     printf '%s/.mastermind/.installed' "$PROJECT"
   else
-    local key; key="$(printf '%s' "$PROJECT" | tr -c 'A-Za-z0-9._-' '_')"
-    printf '%s/projects/%s' "$state" "$key"
+    # Hashed, not sanitised: replacing every unsafe character with _ made /a/b and /a_b the
+    # same file, so two projects shared one record and each inherited the other's tools.
+    local key legacy
+    key="$(printf '%s' "$PROJECT" | mm_hash_stdin | cut -c1-16)"
+    legacy="$state/projects/$(printf '%s' "$PROJECT" | tr -c 'A-Za-z0-9._-' '_')"
+    # A record written before the key changed is still the truth for this project, as long as it
+    # says so; a legacy file from a colliding path names a different project and is ignored.
+    if [ ! -f "$state/projects/$key" ] && [ -f "$legacy" ] &&
+       grep -qxF "project=$PROJECT" "$legacy" 2>/dev/null; then
+      printf '%s' "$legacy"
+    else
+      printf '%s/projects/%s' "$state" "$key"
+    fi
   fi
 }
 
@@ -101,6 +116,13 @@ mm_ledger_dirs() {
   local f; f="$(mm_routes_ledger)"
   [ -f "$f" ] || return 0        # no ledger is not an error; set -e would abort the caller
   cat "$f"
+}
+
+mm_hash_stdin() {
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 | cut -d' ' -f1
+  elif command -v sha256sum >/dev/null 2>&1; then sha256sum | cut -d' ' -f1
+  else cksum | cut -d' ' -f1
+  fi
 }
 
 mm_hash() {
@@ -282,7 +304,7 @@ mm_remove_generated() {
   local dst="$1"
   [ -f "$dst" ] || return 1
   if ! mm_is_generated "$dst"; then
-    warn "left $(basename "$dst") alone — it is not the file we generated"
+    warn "left $(basename "$dst") alone: it is not the file we generated"
     return 1
   fi
   rm -f "$dst"; ok "removed $(basename "$dst")"
@@ -336,18 +358,18 @@ link_skill() {
     ISSUES=$((ISSUES + 1)); return 1
   fi
 
-  # The project owns BOTH names — refuse rather than clobber anything of theirs.
+  # The project owns BOTH names: refuse rather than clobber anything of theirs.
   if [ "$renamed" = 1 ] && path_exists "$alt" && ! is_ours "$alt"; then
-    warn "you own both '$name' and 'mastermind-$name' — MasterMind's $kind skipped"
+    warn "you own both '$name' and 'mastermind-$name': MasterMind's $kind skipped"
     SKIPPED=$((SKIPPED + 1)); return 1
   fi
 
   ln -sfn "$(mm_link_src "$src" "$target")" "$target"
   if [ "$renamed" = 1 ]; then
-    warn "you already have a $kind '$name' — installed MasterMind's as 'mastermind-$name' (both work)"
+    warn "you already have a $kind '$name': installed MasterMind's as 'mastermind-$name' (both work)"
     RENAMED=$((RENAMED + 1))
   elif is_ours "$alt"; then
-    # Their colliding file is gone, so ours reclaimed the real name — drop the alias.
+    # Their colliding file is gone, so ours reclaimed the real name: drop the alias.
     rm -f "$alt"
   fi
   return 0
@@ -361,7 +383,10 @@ wire_brain_file() {
     return
   fi
   mkdir -p "$(dirname "$dst")"
-  if [ -L "$dst" ] && ! is_ours "$dst"; then
+  # "resolves somewhere inside the brain" is not ownership: a project pointing AGENTS.md at
+  # .mastermind/prefs.md had that link replaced with no backup and removed on uninstall. Ours
+  # is the link that points at exactly what we would create.
+  if [ -L "$dst" ] && ! links_to "$dst" "$src"; then
     local bak="$dst.bak-$(date +%Y%m%d%H%M%S)-$$"
     mv "$dst" "$bak"; warn "backed up your existing $(basename "$dst") symlink → $bak"
     printf '%s\n' "$bak" > "$dst.mm-backup"
@@ -376,33 +401,33 @@ wire_brain_file() {
 wire_codex_global() {
   local ovr="$CODEX_HOME_DIR/AGENTS.override.md"
   if [ "$MODE" = check ]; then
-    if [ -s "$ovr" ]; then warn "$CODEX_HOME_DIR/AGENTS.override.md takes priority — MasterMind's global file is ignored by Codex"; return 0; fi
-    if is_wired "$CODEX_GLOBAL"; then warn "$CODEX_GLOBAL wired (may not reach project chats — openai/codex#27705)"
+    if [ -s "$ovr" ]; then warn "$CODEX_HOME_DIR/AGENTS.override.md takes priority: MasterMind's global file is ignored by Codex"; return 0; fi
+    if is_wired "$CODEX_GLOBAL"; then warn "$CODEX_GLOBAL wired (may not reach project chats: openai/codex#27705)"
     else bad "$CODEX_GLOBAL not wired to MasterMind"; ISSUES=$((ISSUES + 1)); fi
     return 0
   fi
   wire_brain_file "$CODEX_GLOBAL" "$BRAIN/AGENTS.md"
-  [ -s "$ovr" ] && warn "you have AGENTS.override.md — Codex reads that instead, so this file won't apply"
-  warn "Codex may not merge global instructions into a project that has its own AGENTS.md (openai/codex#27705) — run install.sh inside each project for the reliable path"
+  [ -s "$ovr" ] && warn "you have AGENTS.override.md: Codex reads that instead, so this file won't apply"
+  warn "Codex may not merge global instructions into a project that has its own AGENTS.md (openai/codex#27705): run install.sh inside each project for the reliable path"
   return 0
 }
 
-# Cursor rule (its own file, always ours) — needs alwaysApply frontmatter to load.
+# Cursor rule (its own file, always ours): needs alwaysApply frontmatter to load.
 wire_cursor() {
   local dst="$PROJECT/.cursor/rules/mastermind.mdc"
   if [ "$MODE" = check ]; then
     if mm_is_generated "$dst" && grep -q 'Prime directives' "$dst"; then ok ".cursor/rules/mastermind.mdc"
-    elif [ -f "$dst" ]; then bad ".cursor rule is the old pointer-only shape — re-run install.sh"; ISSUES=$((ISSUES + 1))
+    elif [ -f "$dst" ]; then bad ".cursor rule is the old pointer-only shape: re-run install.sh"; ISSUES=$((ISSUES + 1))
     else bad ".cursor rule not set"; ISSUES=$((ISSUES + 1)); fi
     return
   fi
   mkdir -p "$PROJECT/.cursor/rules"
   mm_preserve_foreign "$dst"
   { printf -- '---\nalwaysApply: true\n---\n'
-    printf -- '<!-- Generated by ~/.mastermind/install.sh — do not edit. Refresh with: npx mastermind-brain -->\n\n'
+    printf -- '<!-- Generated by ~/.mastermind/install.sh: do not edit. Refresh with: npx mastermind-brain -->\n\n'
     cat "$BRAIN/CLAUDE.md"
   } > "$dst"
-  ok ".cursor/rules/mastermind.mdc — full kernel inlined"
+  ok ".cursor/rules/mastermind.mdc: full kernel inlined"
   wire_cursor_field
   wire_cursor_hook
 }
@@ -417,7 +442,7 @@ wire_cursor_field() {
   if [ -z "$field" ] || [ ! -d "$BRAIN/engineering/fields/$field" ]; then
     if [ "$MODE" = check ]; then
       if mm_is_generated "$dst"; then
-        bad ".cursor/rules/mastermind-field.mdc is left over from a field that no longer exists — re-run install.sh"
+        bad ".cursor/rules/mastermind-field.mdc is left over from a field that no longer exists: re-run install.sh"
         ISSUES=$((ISSUES + 1))
       fi
       return
@@ -429,12 +454,12 @@ wire_cursor_field() {
 
   if [ "$MODE" = check ]; then
     if mm_is_generated "$dst" && grep -qF "$field" "$dst"; then
-      ok ".cursor/rules/mastermind-field.mdc — $field pack inlined"
+      ok ".cursor/rules/mastermind-field.mdc: $field pack inlined"
     elif [ -f "$dst" ]; then
-      bad ".cursor/rules/mastermind-field.mdc does not carry the '$field' pack — re-run install.sh"
+      bad ".cursor/rules/mastermind-field.mdc does not carry the '$field' pack: re-run install.sh"
       ISSUES=$((ISSUES + 1))
     else
-      bad "field pack '$field' exists but is not delivered to Cursor — re-run install.sh"
+      bad "field pack '$field' exists but is not delivered to Cursor: re-run install.sh"
       ISSUES=$((ISSUES + 1))
     fi
     return
@@ -442,7 +467,7 @@ wire_cursor_field() {
 
   local f had=0
   { printf -- '---\nalwaysApply: true\n---\n'
-    printf -- '<!-- Generated by ~/.mastermind/install.sh — do not edit. Refresh with: npx mastermind-brain -->\n'
+    printf -- '<!-- Generated by ~/.mastermind/install.sh: do not edit. Refresh with: npx mastermind-brain -->\n'
     printf -- '\n# Active field pack: %s\n\nThe stack knowledge for this project. Apply it as your default;\n' "$field"
     printf -- 'the rest of the pack (mentors, curriculum, audit rules) is on disk under\n`.mastermind/engineering/fields/%s/` and loads on demand.\n' "$field"
     for f in stack-defaults.md lessons.md; do
@@ -453,8 +478,8 @@ wire_cursor_field() {
 
   if [ "$had" = 0 ]; then rm -f "$dst"; return; fi
   local kb=$(( $(wc -c < "$dst") / 1024 ))
-  ok ".cursor/rules/mastermind-field.mdc — $field pack inlined (${kb}KB)"
-  [ "$kb" -gt 60 ] && warn "that pack is large for always-on context — prune it with levelup, or Cursor pays it every request"
+  ok ".cursor/rules/mastermind-field.mdc: $field pack inlined (${kb}KB)"
+  [ "$kb" -gt 60 ] && warn "that pack is large for always-on context: prune it with levelup, or Cursor pays it every request"
   return 0
 }
 
@@ -484,7 +509,7 @@ wire_cursor_hook() {
     }
     fs.writeFileSync(p, JSON.stringify(s,null,2)+"\n");
   ' 2>/dev/null \
-    && ok ".cursor/hooks.json — sessionStart + preCompact (unverified upstream)" \
+    && ok ".cursor/hooks.json: sessionStart + preCompact (unverified upstream)" \
     || warn "left your .cursor/hooks.json alone (could not parse it)"
   return 0
 }
@@ -514,7 +539,7 @@ wire_claude() {
   if [ "$MODE" != check ]; then
     ok "$LINKED_SKILLS skills, $LINKED_AGENTS agents linked · $PRUNED stale removed"
     if [ "$RENAMED" -gt 0 ]; then
-      warn "$RENAMED name(s) clashed with your own — yours kept, ours added as mastermind-*"
+      warn "$RENAMED name(s) clashed with your own: yours kept, ours added as mastermind-*"
     fi
   fi
   wire_bootstrap "$base"
@@ -532,7 +557,7 @@ wire_bootstrap() {
   fi
 
   if ! command -v node >/dev/null 2>&1; then
-    warn "node not found — skipped the bootstrap hook (brain won't survive a compaction)"
+    warn "node not found: skipped the bootstrap hook (brain won't survive a compaction)"
     return 0
   fi
 
@@ -547,7 +572,7 @@ wire_bootstrap() {
     }
     s.hooks ||= {};
     const list = (s.hooks.SessionStart ||= []);
-    // Drop any previous MasterMind entry, then re-add — keeps other tools hooks intact.
+    // Drop any previous MasterMind entry, then re-add: keeps other tools hooks intact.
     // Ownership is the command path, not a substring: another tool at
     // /their/tool/session-start.sh matched the old check and was deleted.
     const mine = (e) => (e?.hooks || []).some((h) => {
@@ -562,8 +587,8 @@ wire_bootstrap() {
     s.hooks.SessionStart = clean;
     fs.writeFileSync(p, JSON.stringify(s, null, 2) + "\n");
   ' 2>/dev/null \
-    && ok "bootstrap hook — kernel re-injected on startup + compaction" \
-    || warn "left your settings.json alone (could not parse it) — bootstrap hook not registered"
+    && ok "bootstrap hook: kernel re-injected on startup + compaction" \
+    || warn "left your settings.json alone (could not parse it): bootstrap hook not registered"
   return 0
 }
 
@@ -751,12 +776,12 @@ if [ "$MODE" = uninstall ]; then
          || [ "$(tr -d '[:space:]' < "$PROJECT/.github/hooks/mastermind.json")" = '{}' ]; then
         rm -f "$PROJECT/.github/hooks/mastermind.json"; ok "removed .github/hooks/mastermind.json"; n=$((n + 1))
       else
-        warn "left .github/hooks/mastermind.json alone — it is not ours"
+        warn "left .github/hooks/mastermind.json alone: it is not ours"
       fi
     fi
     # Cursor's hooks.json is shared: filter our entries out rather than deleting the file.
     if mm_wants cursor && [ -f "$PROJECT/.cursor/hooks.json" ] && ! command -v node >/dev/null 2>&1; then
-      warn "node is not installed, so .cursor/hooks.json was left as it is — our hook is still wired there"
+      warn "node is not installed, so .cursor/hooks.json was left as it is: our hook is still wired there"
       UNFINISHED=$((UNFINISHED + 1))
     fi
     if mm_wants cursor && [ -f "$PROJECT/.cursor/hooks.json" ] && command -v node >/dev/null 2>&1; then
@@ -777,13 +802,13 @@ if [ "$MODE" = uninstall ]; then
       case "$_rc" in
         0) ok "unwired .cursor/hooks.json"; n=$((n + 1)) ;;
         1) : ;;   # nothing of ours in there
-        *) warn "could not edit .cursor/hooks.json (unreadable JSON) — our hook is still wired there"
+        *) warn "could not edit .cursor/hooks.json (unreadable JSON): our hook is still wired there"
            UNFINISHED=$((UNFINISHED + 1)) ;;
       esac
     fi
   fi
   if mm_wants claude && [ -f "$CLAUDE_DIR/settings.json" ] && ! command -v node >/dev/null 2>&1; then
-    warn "node is not installed, so settings.json was left as it is — the bootstrap hook is still registered"
+    warn "node is not installed, so settings.json was left as it is: the bootstrap hook is still registered"
     UNFINISHED=$((UNFINISHED + 1))
   fi
   if mm_wants claude && [ -f "$CLAUDE_DIR/settings.json" ] && command -v node >/dev/null 2>&1; then
@@ -803,7 +828,7 @@ if [ "$MODE" = uninstall ]; then
     case "$_rc" in
       0) ok "unwired the bootstrap hook from settings.json"; n=$((n + 1)) ;;
       1) : ;;
-      *) warn "could not edit settings.json (unreadable JSON) — the bootstrap hook is still registered"
+      *) warn "could not edit settings.json (unreadable JSON): the bootstrap hook is still registered"
          UNFINISHED=$((UNFINISHED + 1)) ;;
     esac
   fi
@@ -815,7 +840,7 @@ if [ "$MODE" = uninstall ]; then
   [ "$SCOPE" = global ] && mm_wants codex && [ -n "${CODEX_GLOBAL:-}" ] && _cleanup_files+=("$CODEX_GLOBAL")
   for f in ${_cleanup_files[@]+"${_cleanup_files[@]}"}; do
     [ -f "$f" ] || continue                        # symlinks are removed above, not edited
-   for HINT in "$HINT_GLOBAL" "$HINT_ISOLATED"; do
+   for HINT in "$HINT_GLOBAL" "$HINT_ISOLATED" "$HINT_LEGACY_GLOBAL" "$HINT_LEGACY_ISOLATED"; do
     grep -qF "$HINT" "$f" || continue
     _pt="$(mktemp)"
       HINT="$HINT" awk 'BEGIN{h=ENVIRON["HINT"]}
@@ -880,7 +905,7 @@ if [ "$MODE" != check ]; then
     :
   elif [ -d "$mm_link" ] && [ ! -L "$mm_link" ]; then
     printf '%s✖ %s is a different brain%s (%s).\n' "$r" "$mm_link" "$x" "${mm_link_real:-unreadable}" >&2
-    printf '  Remove or move it first, then re-run — refusing to write inside someone else'"'"'s clone.\n' >&2
+    printf '  Remove or move it first, then re-run: refusing to write inside someone else'"'"'s clone.\n' >&2
     exit 1
   else
     ln -sfn "$REPO" "$mm_link"
@@ -909,7 +934,7 @@ fi
 if [ "$SCOPE" = project ] && [ "$MODE" = install ] && { [ "$PROJECT" -ef "$REPO" ] || [ "$PROJECT" -ef "$HOME" ]; }; then
   printf 'MasterMind brain → ~/.mastermind  %s✓ ready%s\n\n' "$g" "$x"
   printf 'Now add it to a project:\n'
-  printf '  cd your-project && ~/.mastermind/install.sh      (just that project — recommended)\n'
+  printf '  cd your-project && ~/.mastermind/install.sh      (just that project: recommended)\n'
   printf '  ~/.mastermind/install.sh --global                (Claude Code, every project)\n'
   exit 0
 fi
@@ -917,13 +942,15 @@ fi
 ISO_ENGINE=(CLAUDE.md AGENTS.md engineering/core skills agents hooks bin cli
             scripts/build-router.mjs scripts/check-integrity.mjs)
 ISO_OWNED=(engineering/active-field.md engineering/ROUTER.md)
+ISO_STATE=(VERSION routes.map .manifest .manifest.hashes .installed .routes.generated
+           engineering engineering/contexts engineering/fields)
 
 mm_preserve_engine_directory() {
   local path="$1" rel="$2" keep
   [ -d "$path" ] && [ ! -L "$path" ] || return 0
   keep="$path.yours-$(date +%Y%m%d%H%M%S)-$$"
   mv "$path" "$keep"
-  warn "this release needs a file at $rel, where your project had a directory — yours is kept at $(basename "$keep")"
+  warn "this release needs a file at $rel, where your project had a directory: yours is kept at $(basename "$keep")"
 }
 
 mm_preserve_untracked_engine_file() {
@@ -932,7 +959,7 @@ mm_preserve_untracked_engine_file() {
   if [ -f "$hashes" ] && awk -v rel="$rel" '$2 == rel { found=1 } END { exit !found }' "$hashes" 2>/dev/null; then return 0; fi
   keep="$path.yours-$(date +%Y%m%d%H%M%S)-$$"
   cp -p "$path" "$keep"
-  warn "this release adds $rel, which your project already had — yours is kept at $(basename "$keep")"
+  warn "this release adds $rel, which your project already had: yours is kept at $(basename "$keep")"
 }
 
 sync_isolated_brain() {
@@ -940,7 +967,7 @@ sync_isolated_brain() {
   local SHIPPED; SHIPPED="$(mktemp)"
   local HASHES="$dst/.manifest.hashes" NEWHASH; NEWHASH="$(mktemp)"
   if [ -L "$dst" ]; then
-    printf '%s✖ .mastermind is a symlink (→ %s).%s Refusing to write through it — remove it first.\n' \
+    printf '%s✖ .mastermind is a symlink (→ %s).%s Refusing to write through it: remove it first.\n' \
       "$r" "$(readlink "$dst")" "$x" >&2; exit 1
   fi
   if path_exists "$dst" && [ ! -d "$dst" ]; then
@@ -948,7 +975,12 @@ sync_isolated_brain() {
   fi
   mkdir -p "$dst"
 
-  for d in "${ISO_ENGINE[@]}" "${ISO_OWNED[@]}"; do mm_assert_no_symlink_path "$dst" "$d"; done
+  # Every path this installer writes under the brain, not only the shipped engine files. A
+  # dangling symlink at routes.map or .manifest.hashes made the write land outside the project
+  # and still exit 0. Anything added below has to be listed here too.
+  for d in "${ISO_ENGINE[@]}" "${ISO_OWNED[@]}" "${ISO_STATE[@]}"; do
+    mm_assert_no_symlink_path "$dst" "$d"
+  done
 
   local ef erel
   for d in "${ISO_ENGINE[@]}"; do
@@ -1070,7 +1102,7 @@ mm_write_block() {
   [ -n "$kept" ] && printf '%s\n\n' "$kept" >> "$tmp"
   {
     printf '%s\n' "$MM_START"
-    printf '<!-- generated by install.sh — edit above or below, never inside -->\n'
+    printf '<!-- generated by install.sh: edit above or below, never inside -->\n'
     printf '%s\n' "$body"
     printf '%s\n' "$MM_END"
   } >> "$tmp"
@@ -1089,7 +1121,7 @@ generate_context_anchors() {
     [ -n "$default_field" ] && [ ! -d "$BRAIN/engineering/fields/$default_field" ] && default_field=""
   fi
   case "$default_field" in *[!A-Za-z0-9_-]*)
-    warn "field name '$default_field' has characters that cannot be templated — ignoring it"
+    warn "field name '$default_field' has characters that cannot be templated: ignoring it"
     default_field="" ;;
   esac
   if [ -z "$default_field" ]; then
@@ -1104,19 +1136,19 @@ generate_context_anchors() {
     line="${line%%[[:space:]]#*}"; line="$(printf '%s' "$line" | awk '{$1=$1};1')"
     [ -n "$line" ] || continue
     if [ "$(printf '%s' "$line" | wc -w | tr -d ' ')" -lt 2 ]; then
-      warn "routes.map: '$line' is not '<glob> <context>' — skipped"; ISSUES=$((ISSUES + 1)); continue
+      warn "routes.map: '$line' is not '<glob> <context>': skipped"; ISSUES=$((ISSUES + 1)); continue
     fi
     glob="${line% *}"; ctx="${line##* }"
     case "$ctx" in *[!A-Za-z0-9_-]*)
-      warn "routes.map: context '$ctx' has invalid characters (use letters, digits, - or _) — skipped"
+      warn "routes.map: context '$ctx' has invalid characters (use letters, digits, - or _): skipped"
       ISSUES=$((ISSUES + 1)); continue ;;
     esac
 
     local adir="${glob%/\*\*}"; adir="${adir%/\*}"; adir="${adir%/}"
     case "$adir" in ''|'*'|'.'|'**') continue ;; esac
     # `../outside/**` reproducibly wrote into a sibling directory.
-    case "$adir" in /*|*\\*) warn "routes.map: '$glob' must be a relative path inside the project — skipped"; ISSUES=$((ISSUES + 1)); continue ;; esac
-    case "/$adir/" in */../*) warn "routes.map: '$glob' may not contain '..' — skipped"; ISSUES=$((ISSUES + 1)); continue ;; esac
+    case "$adir" in /*|*\\*) warn "routes.map: '$glob' must be a relative path inside the project: skipped"; ISSUES=$((ISSUES + 1)); continue ;; esac
+    case "/$adir/" in */../*) warn "routes.map: '$glob' may not contain '..': skipped"; ISSUES=$((ISSUES + 1)); continue ;; esac
     local abs="$PROJECT/$adir"
     mm_assert_contained "$abs"
     for _gt in "$abs/CLAUDE.md" "$abs/AGENTS.md" "$abs/.cursor/rules/mastermind.mdc"; do
@@ -1124,13 +1156,15 @@ generate_context_anchors() {
     done
     mm_assert_real_file "$abs/.cursor/rules/mastermind.mdc"
     unset _gt
-    if [ ! -d "$abs" ]; then warn "routes.map: '$glob' → no directory $adir/ — skipped"; continue; fi
+    if [ ! -d "$abs" ]; then warn "routes.map: '$glob' → no directory $adir/: skipped"; continue; fi
     if ! abs="$(mm_resolve_inside_project "$abs")"; then
-      warn "routes.map: '$glob' resolves outside the project — skipped"; ISSUES=$((ISSUES + 1)); continue
+      warn "routes.map: '$glob' resolves outside the project: skipped"; ISSUES=$((ISSUES + 1)); continue
     fi
 
     # Seed the context from the template on first use, then read the field it names.
     local cdir="$BRAIN/engineering/contexts/$ctx"
+    # $ctx comes from routes.map, so the repository names this path, not us.
+    mm_assert_no_symlink_path "$BRAIN" "engineering/contexts/$ctx"
     if [ ! -d "$cdir" ]; then
       local tpl="$BRAIN/engineering/_context_template"; [ -d "$tpl" ] || tpl="$REPO/engineering/_context_template"
       mkdir -p "$cdir"
@@ -1139,7 +1173,7 @@ generate_context_anchors() {
     fi
     local field; field="$(sed -n 's/^field:[[:space:]]*//p' "$cdir/field.md" | head -1)"; field="${field:-$default_field}"
     if [ -z "$field" ] || [ ! -d "$BRAIN/engineering/fields/$field" ]; then
-      warn "context '$ctx' needs a field this brain doesn't have yet (${field:-none set}). Run init to build a field, then re-run install — skipped for now."
+      warn "context '$ctx' needs a field this brain doesn't have yet (${field:-none set}). Run init to build a field, then re-run install: skipped for now."
       ISSUES=$((ISSUES + 1)); continue
     fi
 
@@ -1154,7 +1188,7 @@ generate_context_anchors() {
     mm_write_block "$abs/AGENTS.md" "$imports"
     mkdir -p "$abs/.cursor/rules"
     { printf -- '---\nglobs: %s\ndescription: MasterMind context for %s\n---\n' "$glob" "$ctx"
-      printf -- '<!-- %s — do not edit. Refresh with: npx mastermind-brain -->\n' "$MM_GEN_MARK"
+      printf -- '<!-- %s: do not edit. Refresh with: npx mastermind-brain -->\n' "$MM_GEN_MARK"
       printf 'This app uses the MasterMind **%s** field and the **%s** context.\n' "$field" "$ctx"
       printf 'Its knowledge is in `%s.mastermind/engineering/fields/%s/` and `.../contexts/%s/`.\n' "$pfx" "$field" "$ctx"
       printf 'The repo-root `.cursor/rules/mastermind.mdc` carries the full kernel; this only routes.\n'
@@ -1169,7 +1203,7 @@ seed_routes_example() {
   local map="$BRAIN/routes.map"
   [ -f "$map" ] && return 0
   cat > "$map" <<'RMAP'
-# routes.map — per-app field/context routing (monorepos). One rule per line:
+# routes.map: per-app field/context routing (monorepos). One rule per line:
 #   <path-glob>   <context-name>
 # The installer compiles each rule into that directory's native, tool-enforced anchor
 # (nested CLAUDE.md / AGENTS.md + a glob-scoped Cursor rule). A missing context is created
@@ -1184,13 +1218,13 @@ RMAP
 
 if [ "$ISOLATED" = 1 ] && [ "$MODE" = install ]; then
   sync_isolated_brain
-  ok "isolated brain → .mastermind/ (v$(cat "$BRAIN/VERSION")) — this project's own field, lessons and stack"
+  ok "isolated brain → .mastermind/ (v$(cat "$BRAIN/VERSION")): this project's own field, lessons and stack"
   seed_routes_example
   generate_context_anchors
 fi
 
 if [ "$MODE" != check ]; then
-  printf 'MasterMind → %s%s%s\n' "$g" "$([ "$SCOPE" = global ] && echo "global — every project" || echo "this project")" "$x"
+  printf 'MasterMind → %s%s%s\n' "$g" "$([ "$SCOPE" = global ] && echo "global: every project" || echo "this project")" "$x"
 fi
 
 links_to() {
@@ -1217,9 +1251,9 @@ is_wired() {
 # --- Which tools? -------------------------------------------------------------
 if [ ${#TOOLS[@]} -eq 0 ]; then
   if [ "$MODE" = check ]; then
-    # Say it out loud when we switched scope — a silent switch is its own confusion.
+    # Say it out loud when we switched scope: a silent switch is its own confusion.
     [ "${CHECK_SCOPE_SWITCHED:-0}" = 1 ] &&
-      printf '%sno project here — checking the global install instead.%s\n\n' "$y" "$x"
+      printf '%sno project here: checking the global install instead.%s\n\n' "$y" "$x"
     _recf="$(mm_record_file)"
     if [ -f "$_recf" ]; then
       _want="$(sed -n 's/^digest=//p' "$_recf" | head -1)"
@@ -1233,7 +1267,7 @@ if [ ${#TOOLS[@]} -eq 0 ]; then
       for _t in $_rec; do TOOLS+=("$_t"); done
       unset _rec _t
     else
-      warn "no install record here — checking only what is still present, so a removed integration may go unreported"
+      warn "no install record here: checking only what is still present, so a removed integration may go unreported"
     fi
     # verify only what's actually wired here (or globally with --global)
     [ ${#TOOLS[@]} -eq 0 ] && is_wired "$CLAUDE_DIR/CLAUDE.md" && TOOLS+=("claude")
@@ -1255,7 +1289,7 @@ if [ ${#TOOLS[@]} -eq 0 ]; then
     fi
     if [ ${#TOOLS[@]} -eq 0 ]; then
       warn "No supported tool detected."
-      echo "  You need an AI coding tool first — e.g. Claude Code: https://claude.com/claude-code"
+      echo "  You need an AI coding tool first: e.g. Claude Code: https://claude.com/claude-code"
     fi
   fi
 fi
@@ -1265,17 +1299,17 @@ for tool in ${TOOLS[@]+"${TOOLS[@]}"}; do
     claude)  wire_claude "$CLAUDE_DIR" ;;
     agents|agents.md)
       printf '\nAGENTS.md:\n'
-      if [ -z "$AGENTS_FILE" ]; then warn "AGENTS.md is per-project — run this inside a project"
+      if [ -z "$AGENTS_FILE" ]; then warn "AGENTS.md is per-project: run this inside a project"
       else wire_brain_file "$AGENTS_FILE" "$BRAIN/AGENTS.md"; fi ;;
     cursor)
-      if [ "$SCOPE" = global ]; then printf '\nCursor:\n'; warn "Cursor rules are per-project — run this inside a project"
+      if [ "$SCOPE" = global ]; then printf '\nCursor:\n'; warn "Cursor rules are per-project: run this inside a project"
       else printf '\nCursor:\n'; wire_cursor; fi ;;
     codex)
       printf '\nCodex:\n'
       if [ "$SCOPE" = global ]; then wire_codex_global
       else wire_brain_file "$AGENTS_FILE" "$BRAIN/AGENTS.md"; fi ;;
     gemini|copilot)
-      warn "$tool is no longer wired automatically — MasterMind is plain Markdown, so point it at $([ "$ISOLATED" = 1 ] && echo '.mastermind/CLAUDE.md' || echo '~/.mastermind/CLAUDE.md') and it works the same." ;;
+      warn "$tool is no longer wired automatically: MasterMind is plain Markdown, so point it at $([ "$ISOLATED" = 1 ] && echo '.mastermind/CLAUDE.md' || echo '~/.mastermind/CLAUDE.md') and it works the same." ;;
     *) warn "skipping unknown tool: $tool";;
   esac
 done
@@ -1283,7 +1317,10 @@ done
 if [ "$MODE" = install ]; then
   _rec_prev=""; _recf="$(mm_record_file)"
   [ -f "$_recf" ] && _rec_prev="$(sed -n 's/^tools=//p' "$_recf")"
-  _rec_all="$(printf '%s %s\n' "$_rec_prev" "${TOOLS[*]}" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ')"
+  # Retired names are accepted so `--uninstall gemini` still works, but recording them made the
+  # doctor expect wiring that was never created and then report the install healthy.
+  _rec_all="$(printf '%s %s\n' "$_rec_prev" "${TOOLS[*]}" | tr ' ' '\n' | grep -v '^$' |
+    grep -vxE 'gemini|copilot' | sort -u | tr '\n' ' ')"
   _rec_all="${_rec_all% }"
   mkdir -p "$(dirname "$_recf")"
   { printf 'version=%s\n' "$(cat "$REPO/VERSION" 2>/dev/null || echo unknown)"
@@ -1310,7 +1347,7 @@ check_routes() {
     fi
     glob="${line% *}"; ctx="${line##* }"
     if [ ! -d "$BRAIN/engineering/contexts/$ctx" ]; then
-      bad "routes.map: context '$ctx' has no dir — re-run install.sh"; ISSUES=$((ISSUES + 1)); continue
+      bad "routes.map: context '$ctx' has no dir: re-run install.sh"; ISSUES=$((ISSUES + 1)); continue
     fi
     field="$(sed -n 's/^field:[[:space:]]*//p' "$BRAIN/engineering/contexts/$ctx/field.md" 2>/dev/null | head -1)"
     [ -d "$BRAIN/engineering/fields/$field" ] || { bad "routes.map: context '$ctx' names missing field '$field'"; ISSUES=$((ISSUES + 1)); continue; }
@@ -1324,7 +1361,7 @@ check_routes() {
         AGENTS.md) { mm_wants agents || mm_wants codex; } || continue ;;
       esac
       if [ ! -f "$PROJECT/$adir/$_f" ] || ! grep -q 'MASTERMIND:START' "$PROJECT/$adir/$_f"; then
-        bad "route $adir/ → $ctx: $_f anchor missing — re-run install.sh"; _bad=1; continue
+        bad "route $adir/ → $ctx: $_f anchor missing: re-run install.sh"; _bad=1; continue
       fi
       grep -qF "engineering/contexts/$ctx/" "$PROJECT/$adir/$_f" ||
         { bad "route $adir/ → $ctx: $_f does not import context '$ctx'"; _bad=1; }
@@ -1336,7 +1373,7 @@ check_routes() {
         grep -qF "$ctx" "$PROJECT/$adir/.cursor/rules/mastermind.mdc" ||
           { bad "route $adir/ → $ctx: the Cursor rule does not name this context"; _bad=1; }
       else
-        bad "route $adir/ → $ctx: the Cursor rule is missing — re-run install.sh"; _bad=1
+        bad "route $adir/ → $ctx: the Cursor rule is missing: re-run install.sh"; _bad=1
       fi
     fi
     if [ "$_bad" = 0 ]; then ok "route $adir/ → $ctx ($field)"
@@ -1349,13 +1386,13 @@ check_routes() {
 if [ "$MODE" = check ]; then
   echo
   if [ "$ISSUES" -eq 0 ]; then
-    printf '%s✓ MasterMind is healthy here — every wired tool resolves.%s\n' "$g" "$x"
+    printf '%s✓ MasterMind is healthy here: every wired tool resolves.%s\n' "$g" "$x"
     if [ "$ISOLATED" = 1 ] && [ -f "$BRAIN/VERSION" ]; then
       pv="$(cat "$BRAIN/VERSION")"; cv="$(cat "$REPO/VERSION" 2>/dev/null || echo "$pv")"
       if [ "$pv" != "$cv" ]; then
         printf '  %s⬆ this project is on v%s; the clone has v%s.%s  Refresh:  ~/.mastermind/install.sh\n' "$y" "$pv" "$cv" "$x"
       else
-        printf '  isolated brain v%s — up to date with the clone.\n' "$pv"
+        printf '  isolated brain v%s: up to date with the clone.\n' "$pv"
       fi
     fi
     check_updates; exit 0
@@ -1367,4 +1404,4 @@ if [ "$SCOPE" = project ]; then
   printf 'On another tool? It reads AGENTS.md, or point it at %s.\n' "$([ "$ISOLATED" = 1 ] && echo '.mastermind/CLAUDE.md' || echo '~/.mastermind/CLAUDE.md')"
 fi
 printf 'Update: cd ~/.mastermind && git pull && ~/.mastermind/install.sh   ·   Verify: ~/.mastermind/install.sh --check\n'
-printf "\nDone — now RESTART your tool. (Until you restart, the brain isn't loaded yet.)\n"
+printf "\nDone: now RESTART your tool. (Until you restart, the brain isn't loaded yet.)\n"

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -393,6 +393,77 @@ is "the first root file survives"   "$(cat "$P"/.mastermind/CLAUDE.md.yours-* 2>
 is "the nested engine file replaces the collision" "$(count_in "$P/.mastermind/engineering/core/mindset.md" 'FIRST NESTED FILE')" "0"
 is "the root engine file replaces the collision"   "$(count_in "$P/.mastermind/CLAUDE.md" 'FIRST ROOT FILE')" "0"
 
+# ══ Every path the brain writes, not only the shipped engine files ═══════════
+# The containment guard covered ISO_ENGINE and ISO_OWNED. It did not cover the state files or
+# the context and field directories, so a dangling symlink at one of them made the write land
+# outside the project while the install still exited 0.
+echo "── a symlink at any brain path is refused, not written through"
+for _p in routes.map .manifest .manifest.hashes .installed .routes.generated VERSION \
+          engineering/contexts engineering/fields; do
+  P=$(proj "esc$(printf '%s' "$_p" | tr -c 'a-z' 'x')")
+  OUT="$TMP_REAL/victims/escape-$$"; rm -f "$OUT"
+  mkdir -p "$P/.mastermind/$(dirname "$_p")"
+  ln -s "$OUT" "$P/.mastermind/$_p"
+  run "$P" claude >/dev/null 2>&1 || true
+  is "$_p cannot escape the project" "$([ -e "$OUT" ] && echo escaped || echo contained)" "contained"
+done
+
+# The context directory is named by routes.map, so the repository chooses the path.
+echo "── a context path named by routes.map is checked too"
+P=$(proj ctxescape); mkdir -p "$P/apps/web"
+run "$P" claude cursor >/dev/null 2>&1
+cp -R "$P/.mastermind/engineering/fields/_template" "$P/.mastermind/engineering/fields/frontend"
+printf 'apps/web webctx\n' > "$P/.mastermind/routes.map"
+CTXOUT="$TMP_REAL/victims/ctx-$$"; rm -f "$CTXOUT"
+mkdir -p "$P/.mastermind/engineering/contexts"
+ln -s "$CTXOUT" "$P/.mastermind/engineering/contexts/webctx"
+out=$(run "$P" claude cursor 2>&1) || true
+is "the context symlink is refused"  "$(printf '%s' "$out" | grep -c 'points outside the brain')" "1"
+is "and nothing was created outside" "$([ -e "$CTXOUT" ] && echo escaped || echo contained)" "contained"
+
+# ══ A link of theirs that happens to point into the brain is still theirs ═════
+# Ownership meant "resolves somewhere inside .mastermind", so a project pointing AGENTS.md at
+# its own file in there had that link replaced with no backup and removed on uninstall.
+echo "── a project's own link into the brain survives"
+P=$(proj theirlink)
+run "$P" claude >/dev/null 2>&1
+printf 'MY PREFS\n' > "$P/.mastermind/prefs.md"
+rm -f "$P/AGENTS.md"; ln -s .mastermind/prefs.md "$P/AGENTS.md"
+run "$P" claude agents >/dev/null 2>&1
+is "ours is wired"            "$(readlink "$P/AGENTS.md")" ".mastermind/AGENTS.md"
+is "theirs was backed up"     "$(ls "$P"/AGENTS.md.bak-* 2>/dev/null | wc -l | tr -d ' ')" "1"
+run "$P" --uninstall >/dev/null 2>&1
+is "and theirs is handed back" "$(readlink "$P/AGENTS.md")" ".mastermind/prefs.md"
+
+# ══ Two projects, two records ════════════════════════════════════════════════
+# Sanitising the path made /a/b and /a_b the same filename, so each project inherited the
+# other's expected tools.
+echo "── project paths that sanitise alike keep separate records"
+mkdir -p "$TMP/coll/a/b" "$TMP/coll/a_b"
+(cd "$TMP/coll/a/b" && git init -q .); (cd "$TMP/coll/a_b" && git init -q .)
+(cd "$TMP/coll/a/b" && HOME="$SANDBOX_HOME" "$INSTALL" --shared claude >/dev/null 2>&1)
+(cd "$TMP/coll/a_b" && HOME="$SANDBOX_HOME" "$INSTALL" --shared claude cursor >/dev/null 2>&1)
+is "the nested project kept its own tools" \
+   "$(grep -rlxF "project=$TMP_REAL/coll/a/b" "$SANDBOX_HOME/.mastermind-state/projects" 2>/dev/null | head -1 | xargs -I{} grep -c '^tools=claude$' {} 2>/dev/null || echo 0)" "1"
+
+# ══ Retired names are accepted, never recorded ═══════════════════════════════
+echo "── a retired tool name does not become expected wiring"
+P=$(proj retired)
+run "$P" claude gemini >/dev/null 2>&1
+is "gemini is not in the record" "$(count_in "$P/.mastermind/.installed" 'gemini')" "0"
+is "claude still is"             "$(count_in "$P/.mastermind/.installed" 'tools=claude')" "1"
+
+# ══ The pointer we wrote before today is still ours to remove ════════════════
+# Releases up to 0.31.2 wrote the hint with an em dash. Cleanup matches whole lines, so the old
+# form has to stay recognised or our text is stranded in every existing user's file.
+echo "── a pointer written by an older release is still cleaned up"
+P=$(proj legacyhint)
+printf 'their notes\n\nFollow ./.mastermind/CLAUDE.md — the MasterMind brain for this project (skills, agents, engineering rigor).\n' > "$P/AGENTS.md"
+run "$P" claude >/dev/null 2>&1
+run "$P" --uninstall >/dev/null 2>&1
+is "the legacy pointer is gone"  "$(count_in "$P/AGENTS.md" 'the MasterMind brain for this project')" "0"
+is "their own text stayed"       "$(count_in "$P/AGENTS.md" 'their notes')" "1"
+
 # ══ The install record is data, so the doctor must survive it being wrong ═════
 echo "── a corrupted or hostile install record does not break the doctor"
 P=$(proj badrecord)
@@ -537,18 +608,18 @@ is "a mention alone is not wired" "$(run "$P" --check 2>&1 | grep -c "isn't set 
 echo "── a shared install leaves an expected-integration record"
 P=$(proj sharedrecord)
 run "$P" --shared claude cursor >/dev/null 2>&1
-_key="$(printf '%s' "$P" | tr -c 'A-Za-z0-9._-' '_')"
-is "the record lists both tools" "$(count_in "$SANDBOX_HOME/.mastermind-state/projects/$_key" 'tools=claude cursor')" "1"
+_recf="$(grep -rlxF "project=$P" "$SANDBOX_HOME/.mastermind-state/projects" 2>/dev/null | head -1)"
+is "the record lists both tools" "$(count_in "${_recf:-/nonexistent}" 'tools=claude cursor')" "1"
 # The record has to track removals too, or the doctor keeps demanding wiring the user dropped.
 run "$P" --uninstall cursor >/dev/null 2>&1
-is "a targeted uninstall drops that tool" "$(count_in "$SANDBOX_HOME/.mastermind-state/projects/$_key" 'cursor')" "0"
+is "a targeted uninstall drops that tool" "$(count_in "${_recf:-/nonexistent}" 'cursor')" "0"
 (cd "$P" && HOME="$SANDBOX_HOME" "$INSTALL" --check >"$TMP/check-shared-after-targeted-uninstall" 2>&1); rc=$?
 is "the shared doctor trusts the rewritten record" \
    "$(grep -c 'edited by hand' "$TMP/check-shared-after-targeted-uninstall" || true)" "0"
 is "the remaining shared integration is healthy" "$rc" "0"
 run "$P" --uninstall >/dev/null 2>&1
-_key="$(printf '%s' "$P" | tr -c 'A-Za-z0-9._-' '_')"
-is "a bare uninstall drops the record"    "$([ -f "$SANDBOX_HOME/.mastermind-state/projects/$_key" ] && echo present || echo gone)" "gone"
+_recf="$(grep -rlxF "project=$P" "$SANDBOX_HOME/.mastermind-state/projects" 2>/dev/null | head -1)"
+is "a bare uninstall drops the record"    "$(grep -rlxF "project=$P" "$SANDBOX_HOME/.mastermind-state/projects" 2>/dev/null | wc -l | tr -d ' ')" "0"
 
 echo "── files we did not generate are preserved, not destroyed"
 P=$(proj ownedpaths)


### PR DESCRIPTION
All 16 findings. Both blockers were real and both were reproduced against the shipped v0.31.2
before anything was changed.

## Blocker: the installer could write outside the project

The containment guard covered the engine files the installer ships and not the state it keeps. A
repository with a **dangling** symlink at `.mastermind/routes.map` or `.manifest.hashes` made the
installer create a file anywhere on the machine, and the install still **exited 0**.

Every path the brain writes is checked now, including the context directories `routes.map` names
at run time, which previously died on a raw `mkdir` error rather than refusing.

## Blocker: the release could publish to npm and then fail

Release notes were read from the changelog **after** `npm publish`, so a missing section shipped
a version permanently and left no Release behind it.

Looking at it turned up something worse: `npm publish` **repacked** the package rather than
publishing the file that had just been verified, so what shipped was never the artifact any check
had inspected. One tarball is now packed, verified and published, and the cross-platform job
exercises it with the same pinned npm.

## The rest

- Ownership meant "resolves somewhere inside the brain", so a project pointing `AGENTS.md` at a
  file in `.mastermind/` had that link replaced with no backup and removed on uninstall.
- `a/b` and `a_b` shared one install record and inherited each other's tools. Keys are hashed;
  old-key records are still read.
- Retired tool names were recorded while wiring nothing, and the doctor then reported healthy.
- An unknown flag cloned the brain before refusing.
- The library check fails the release when it cannot read the site, with an explicit override.
- The installer suites run on every PR so a red suite can be a required check.
- `agents` is no longer advertised as a tool you name.
- The map is click-to-load, sandboxed, no referrer. The router copy matches what was measured.
  Copy failures are visible. The Codex link points at the CLI docs.
- 87 em dashes left installer and CLI output. **The pointer line went with them**, so the old
  wording is still recognised on removal: otherwise our text would be stranded in the file of
  everyone who installed before this release.

## Verification

**7 of the new assertions fail against v0.31.2** and pass here, which is what makes them tests
rather than descriptions: both write-escapes, the unrefused context symlink, the user's link lost
twice over, the record collision, and the phantom `gemini` entry.

315 install assertions · 40 agent-surface · 15 preflight checks · shellcheck clean · site builds
with 0 errors and 0 hints.