### PR TITLE
the homepage example reads its measurement, and tags become immutable

### DIFF
--- a/.github/tag-ruleset.json
+++ b/.github/tag-ruleset.json
@@ -2,12 +2,9 @@
   "name": "protect release tags",
   "target": "tag",
   "enforcement": "active",
-  "bypass_actors": [
-    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
-  ],
+  "bypass_actors": [],
   "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
   "rules": [
-    { "type": "creation" },
     { "type": "update" },
     { "type": "deletion" }
   ]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,6 +37,21 @@ it.
 `install.sh`, `cli/`, `bin/`, `tests/`, `hooks/` or `scripts/`, so you find breakage in seconds
 rather than in a CI queue. `MM_SKIP_TESTS=1 git push` overrides it and says so out loud.
 
+## Tags are immutable once pushed
+
+`.github/tag-ruleset.json` stops any `v*` tag being moved or deleted, by anyone, with no bypass.
+Apply it once:
+
+```
+gh api --method POST repos/mehrad-dm/mastermind/rulesets --input .github/tag-ruleset.json
+```
+
+It deliberately does **not** restrict tag creation. Creating a tag is already gated by the
+release workflow, which refuses a commit that is not on `master`, and a creation rule with a
+mis-set bypass would lock releases out entirely. Moving a tag is the real damage: the CLI pins a
+commit and refuses a clone that does not match it, so a moved tag breaks every install rather
+than fixing any, and it makes the GitHub source archive disagree with what npm serves.
+
 ## What the website repository does not have
 
 `mastermind-site` runs CI on pull requests, but nothing requires it to pass: rulesets and branch

--- a/scripts/sync-evals.mjs
+++ b/scripts/sync-evals.mjs
@@ -87,6 +87,11 @@ const routerRouted = avgRow ? num(avgRow[1]) : 0
 const routerSaved = avgRow ? num(avgRow[2]) : 0
 const savings = perTask.map((t) => t.saved)
 
+// The homepage shows one task, not the average, so the number it draws has to come from the same
+// file as everything else. A hardcoded copy stayed green here while the site went stale.
+const example = perTask.find((x) => x.task.toLowerCase() === 'animation (opus)')
+if (!example) die('the animation (opus) row is gone from RESULTS.md, so the homepage example would go stale')
+
 const data = {
   generatedFrom: 'evals/RESULTS.md + engineering/ROUTER.md',
   router: {
@@ -96,6 +101,7 @@ const data = {
     rangeLow: Math.min(...savings),
     rangeHigh: Math.max(...savings),
     source: 'evals/pilot-multimodel/RESULTS.md, measured per task, Opus average of 4 tasks',
+    example: { task: example.task, routed: example.withRouter, savedPct: example.saved },
   },
   headline: {
     date: headlineDate,


### PR DESCRIPTION
Three of the four remaining findings. The website merge gate is deliberately left open.

**The homepage example could drift silently.** `5002` was hardcoded, and `sync-evals.mjs` never exported that row, so the sync check compared everything except the one number the graphic draws. It now comes from `evals.json`, and the sync **fails** if the `animation (opus)` row leaves `RESULTS.md`.

Proven both ways: changing the measurement makes the check exit 1, and deleting the row makes it exit 1 with a named reason. Rendered output is unchanged at `~5,002 tokens`.

**Tag protection, with the creation rule removed.** The committed ruleset restricted `creation` with an unverified `RepositoryRole` bypass id. If that id were wrong, no release tag could ever be pushed again. Creation is already gated by the workflow's ancestor check, so the ruleset now covers `update` and `deletion` only, with no bypass, which is the actual immutability property and carries no lock-out risk.

Not applied yet: applying it writes to repository configuration.

**Stale dependabot comment** on the site claimed the workflows use mutable action tags. They pin by SHA.

Immutable Releases are not available on this repository, so that half of the finding cannot be actioned here.

Gates: preflight 17 of 17.