### PR TITLE
move both CodeQL pins to v4 in one step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           languages: javascript-typescript
           # Eval seeds are deliberately imperfect starting repositories: finding flaws in them
@@ -29,7 +29,7 @@ jobs:
               - evals/runs/**
               - evals/tasks/**
               - lab/**
-      - uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
 
   # CodeQL has no Bash analyzer, and Bash is where the risk actually lives here: the installer
   # resolves paths, follows symlinks and deletes files in someone else's repository. A green


### PR DESCRIPTION
Supersedes #29 and #30.

Dependabot raised `init` and `analyze` as separate pull requests. CodeQL requires both to be the same major version, so each PR on its own left the pair mismatched: `init` at the v3 SHA, `analyze` at the v4 SHA. The analyze step failed on both, and neither could ever go green no matter how often it was rebased. Bumping them together is the only form of this change that passes.

Their patches also left the `# v3` comment beside a v4 SHA. The comment is the only part a reader can check at a glance, so it now says `v4.37.9`, verified against the tag list for that commit.