### PR TITLE
the architecture map shows the Cursor eval it was missing

### DIFF
--- a/.foglamp/scan.json
+++ b/.foglamp/scan.json
@@ -414,6 +414,15 @@
         "sub": "prefs + brief, yours to edit",
         "sourceRef": "prefs.seed.md",
         "detail": "Seeded by the installer and never overwritten: prefs.md holds cycle-report and plan-first, brief.md holds what this project is, its own words, what breaks, and what cannot be undone."
+      },
+      {
+        "id": "cursorrouting",
+        "label": "Cursor routing eval",
+        "kind": "service",
+        "sub": "does the brain steer Cursor?",
+        "group": "Safety & honesty",
+        "sourceRef": "evals/cursor-routing.mjs",
+        "detail": "Installs into a scratch project wired for Cursor alone, then asks a live `cursor-agent` session to name the skill it would use. Attribution is reported, never gated: the agent reads the brain itself."
       }
     ],
     "edges": [
@@ -686,6 +695,12 @@
         "to": "projectstate",
         "kind": "writes",
         "label": "seeds, never overwrites"
+      },
+      {
+        "from": "cursorrouting",
+        "to": "cursor",
+        "kind": "triggers",
+        "label": "drives a live session"
       }
     ]
   }

--- a/scripts/update-scan.mjs
+++ b/scripts/update-scan.mjs
@@ -128,6 +128,16 @@ const NEW_NODES = [
       'Installs into a scratch project wired for Codex alone, then asks a live `codex exec` session to name the skill it would use. Before it, every Codex claim rested on a file being in the right place.',
   },
   {
+    id: 'cursorrouting',
+    label: 'Cursor routing eval',
+    kind: 'service',
+    sub: 'does the brain steer Cursor?',
+    group: 'Safety & honesty',
+    sourceRef: 'evals/cursor-routing.mjs',
+    detail:
+      'Installs into a scratch project wired for Cursor alone, then asks a live `cursor-agent` session to name the skill it would use. Attribution is reported, never gated: the agent reads the brain itself.',
+  },
+  {
     id: 'instructions',
     label: 'Instruction clarity',
     kind: 'service',
@@ -167,6 +177,7 @@ const NEW_EDGES = [
   { from: 'autoinvoke', to: 'install', kind: 'triggers', label: 'installs, then asks' },
   { from: 'secretguards', to: 'lab', kind: 'reads', label: 'never let it out' },
   { from: 'codexrouting', to: 'codex', kind: 'triggers', label: 'drives a live session' },
+  { from: 'cursorrouting', to: 'cursor', kind: 'triggers', label: 'drives a live session' },
   { from: 'instructions', to: 'moreskills', kind: 'reads', label: 'every skill body' },
   { from: 'install', to: 'projectstate', kind: 'writes', label: 'seeds, never overwrites' },
 ]


### PR DESCRIPTION
The map names each live routing eval. It named the Codex one, while the Cursor eval added in 0.32.0 had no node at all, so the picture understated what MasterMind proves about the tools it supports.

Freshness did not catch this: `update-scan.mjs` regenerated `scan.json` byte-identically, because the node it was missing did not exist in the generator either. Freshness only means the generator agrees with itself.

Its own contract did catch my first attempt, twice: the detail ran to 269 characters, then 205, against a 200 limit, and the generator refused both.

No version bump. The map data lives in `.foglamp/scan.json`, and `foglamp.yml` republishes the hosted map on any push to master that changes it, so this reaches the website without a site deploy.